### PR TITLE
Kas 1274

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,6 @@ app.post('/approveAgenda', async (req, res) => {
     // Copy old agenda data to new agenda.
     const agendaData = await util.copyAgendaItems(oldAgendaURI, newAgendaURI);
 
-    await repository.markAgendaItemsPartOfAgendaA(oldAgendaURI);
     await repository.storeAgendaItemNumbers(oldAgendaURI);
 
     try {

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // VIRTUOSO bug: https://github.com/openlink/virtuoso-opensource/issues/515
 import mu from 'mu';
-import {ok} from 'assert';
+import { ok } from 'assert';
 import cors from 'cors';
 
 const app = mu.app;
@@ -12,45 +12,45 @@ const originalQuery = mu.query;
 
 
 mu.query = function (query, retryCount = 0) {
-    let start = moment();
-    return originalQuery(query).catch((error) => {
-        if (retryCount < 3) {
-            console.log(`error during query ${query}: ${error}`);
-            return mu.query(query, retryCount + 1);
-        }
-        console.log(`final error during query ${query}: ${error}`);
-        throw error;
-    }).then((result) => {
-        console.log(`query took: ${moment().diff(start, 'seconds', true).toFixed(3)}s`);
-        return result;
-    });
+  let start = moment();
+  return originalQuery(query).catch((error) => {
+    if (retryCount < 3) {
+      console.log(`error during query ${query}: ${error}`);
+      return mu.query(query, retryCount + 1);
+    }
+    console.log(`final error during query ${query}: ${error}`);
+    throw error;
+  }).then((result) => {
+    console.log(`query took: ${moment().diff(start, 'seconds', true).toFixed(3)}s`);
+    return result;
+  });
 };
 mu.update = mu.query;
 
 app.use(cors());
-app.use(bodyParser.json({type: 'application/*+json'}));
+app.use(bodyParser.json({ type: 'application/*+json' }));
 
 // Approve agenda route
 app.post('/approveAgenda', async (req, res) => {
-    const oldAgendaId = req.body.oldAgendaId;
-    const oldAgendaURI = await repository.getAgendaURI(oldAgendaId);
-    // Create new agenda via query.
-    const [newAgendaId, newAgendaURI] = await repository.createNewAgenda(req, res, oldAgendaURI);
-    // Copy old agenda data to new agenda.
-    const agendaData = await util.copyAgendaItems(oldAgendaURI, newAgendaURI);
+  const oldAgendaId = req.body.oldAgendaId;
+  const oldAgendaURI = await repository.getAgendaURI(oldAgendaId);
+  // Create new agenda via query.
+  const [newAgendaId, newAgendaURI] = await repository.createNewAgenda(req, res, oldAgendaURI);
+  // Copy old agenda data to new agenda.
+  const agendaData = await util.copyAgendaItems(oldAgendaURI, newAgendaURI);
 
-    await repository.storeAgendaItemNumbers(oldAgendaURI);
+  await repository.storeAgendaItemNumbers(oldAgendaURI);
 
-    try {
-        const codeURI = await repository.getSubcasePhaseCode();
-        const subcasePhasesOfAgenda = await repository.getSubcasePhasesOfAgenda(newAgendaId, codeURI);
+  try {
+    const codeURI = await repository.getSubcasePhaseCode();
+    const subcasePhasesOfAgenda = await repository.getSubcasePhasesOfAgenda(newAgendaId, codeURI);
 
-        await util.checkForPhasesAndAssignMissingPhases(subcasePhasesOfAgenda, codeURI);
-    } catch (e) {
-        console.log("something went wrong while assigning the code 'Geagendeerd' to the agendaitems", e);
-    }
+    await util.checkForPhasesAndAssignMissingPhases(subcasePhasesOfAgenda, codeURI);
+  } catch (e) {
+    console.log("something went wrong while assigning the code 'Geagendeerd' to the agendaitems", e);
+  }
 
-    res.send({status: ok, statusCode: 200, body: {agendaData: agendaData, newAgenda:{id: newAgendaId, uri: newAgendaURI, data:  agendaData}}}); // resultsOfSerialNumbers: resultsAfterUpdates
+  res.send({ status: ok, statusCode: 200, body: { agendaData: agendaData, newAgenda: { id: newAgendaId, uri: newAgendaURI, data: agendaData } } }); // resultsOfSerialNumbers: resultsAfterUpdates
 });
 
 mu.app.use(mu.errorHandler);
@@ -58,18 +58,18 @@ mu.app.use(mu.errorHandler);
 // Approve agenda route
 app.post('/deleteAgenda', async (req, res) => {
   const agendaToDeleteId = req.body.agendaToDeleteId;
-  if(!agendaToDeleteId){
-    res.send({statusCode: 400, body: "agendaToDeleteId missing, deletion of agenda failed"});
+  if (!agendaToDeleteId) {
+    res.send({ statusCode: 400, body: "agendaToDeleteId missing, deletion of agenda failed" });
     return;
   }
-  try{
+  try {
     const agendaToDeleteURI = await repository.getAgendaURI(agendaToDeleteId);
     await repository.deleteSubcasePhases(agendaToDeleteURI);
     await repository.deleteAgendaitems(agendaToDeleteURI);
     await repository.deleteAgenda(agendaToDeleteURI);
-    res.send({status: ok, statusCode: 200});
+    res.send({ status: ok, statusCode: 200 });
   } catch (e) {
-      console.log(e);
-    res.send({statusCode: 500, body: "something went wrong while deleting the agenda", e});
+    console.log(e);
+    res.send({ statusCode: 500, body: "something went wrong while deleting the agenda", e });
   }
 });

--- a/repository/index.js
+++ b/repository/index.js
@@ -359,7 +359,7 @@ const deleteSubcasePhases = async (deleteAgendaURI) => {
   }
   `;
   await mu.query(query);
-}
+};
 
 const deleteAgenda = async (deleteAgendaURI) => {
   const query = `
@@ -374,7 +374,9 @@ const deleteAgenda = async (deleteAgendaURI) => {
     GRAPH <${targetGraph}> { 
     <${deleteAgendaURI}> a besluitvorming:Agenda ;
       ?p ?o .
-      ?s ?pp <${deleteAgendaURI}> .
+      OPTIONAL {
+        ?s ?pp <${deleteAgendaURI}> .
+      }
     }
   }`;
     await mu.query(query);

--- a/repository/index.js
+++ b/repository/index.js
@@ -1,7 +1,7 @@
 import mu from 'mu';
 const moment = require('moment');
 const uuidv4 = require('uuid/v4');
-const targetGraph = "http://mu.semte.ch/graphs/organizations/kanselarij";
+const targetGraph = "http://mu.semte.ch/application";
 
 const createNewAgenda = async (req, res, oldAgendaURI) => {
     const newUUID = uuidv4();
@@ -89,32 +89,6 @@ const getSubcasePhasesOfAgenda = async (newAgendaId, codeURI) => {
     });
 };
 
-const markAgendaItemsPartOfAgendaA = async (agendaUri) => {
-    const query = `
-  PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-  PREFIX dbpedia: <http://dbpedia.org/ontology/>
-  PREFIX dct: <http://purl.org/dc/terms/>
-  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-  
-  INSERT {
-    GRAPH <${targetGraph}> {
-      ?agendaItem ext:partOfFirstAgenda """true"""^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
-    }
-  } WHERE {
-    <${agendaUri}> dct:hasPart ?agendaItem .
-    
-    FILTER NOT EXISTS {
-      <${agendaUri}> besluitvorming:heeftVorigeVersie ?o.
-    }      
-  }`;
-    return await mu.query(query).catch(err => {
-        console.error(err)
-    });
-};
-
 const storeAgendaItemNumbers = async (agendaUri) => {
     const maxAgendaItemNumberSoFar = await getHighestAgendaItemNumber(agendaUri);
     let query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
@@ -187,6 +161,7 @@ const getHighestAgendaItemNumber = async (agendaUri) => {
     return parseInt(((response.results.bindings[0] || {})['max'] || {}).value || 0);
 };
 
+//This method is for assigning VR numbers to documents automatically but is currently not being used and will need updating
 const getUnnamedDocumentsOfAgenda = async (agendaUri) => {
     const query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -388,7 +363,6 @@ module.exports = {
     createNewAgenda,
     getSubcasePhaseCode,
     getSubcasePhasesOfAgenda,
-    markAgendaItemsPartOfAgendaA,
     storeAgendaItemNumbers,
     getUnnamedDocumentsOfAgenda,
     createNewSubcasesPhase,

--- a/repository/index.js
+++ b/repository/index.js
@@ -5,8 +5,9 @@ const targetGraph = "http://mu.semte.ch/graphs/organizations/kanselarij";
 
 const createNewAgenda = async (req, res, oldAgendaURI) => {
     const newUUID = uuidv4();
-    const reqTime = moment();
-    const reqTimeFormatted = reqTime.format('YYYY-MM-DD');
+    const reqDate = moment();
+    const reqDateFormatted = reqDate.format('YYYY-MM-DD');
+    const reqDateTimeFormatted = reqDate.utc().format();
     const agendaName = req.body.agendaName;
     const session = req.body.createdFor;
     const query = `
@@ -20,12 +21,13 @@ PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 INSERT DATA {
   GRAPH <${targetGraph}> { 
   agenda:${newUUID} a besluitvorming:Agenda ;
-  ext:aangemaaktOp "${reqTimeFormatted}" ;
+  ext:aangemaaktOp "${reqDateFormatted}" ;
+  ext:aangepastOp "${reqDateTimeFormatted}" ;
   mu:uuid "${newUUID}" ;
   besluit:isAangemaaktVoor <http://kanselarij.vo.data.gift/id/zittingen/${session}> ;
   ext:agendaNaam "${agendaName}" ;
   ext:accepted "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
-  <${oldAgendaURI}> besluitvorming:heeftVorigeVersie agenda:${newUUID};
+  agenda:${newUUID} besluitvorming:heeftVorigeVersie <${oldAgendaURI}>  .
 }
 }`;
     await mu.query(query).catch(err => {

--- a/repository/index.js
+++ b/repository/index.js
@@ -4,13 +4,13 @@ const uuidv4 = require('uuid/v4');
 const targetGraph = "http://mu.semte.ch/application";
 
 const createNewAgenda = async (req, res, oldAgendaURI) => {
-    const newUUID = uuidv4();
-    const reqDate = moment();
-    const reqDateFormatted = reqDate.format('YYYY-MM-DD');
-    const reqDateTimeFormatted = reqDate.utc().format();
-    const agendaName = req.body.agendaName;
-    const session = req.body.createdFor;
-    const query = `
+  const newUUID = uuidv4();
+  const reqDate = moment();
+  const reqDateFormatted = reqDate.format('YYYY-MM-DD');
+  const reqDateTimeFormatted = reqDate.utc().format();
+  const agendaName = req.body.agendaName;
+  const session = req.body.createdFor;
+  const query = `
 PREFIX adms: <http://www.w3.org/ns/adms#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX agenda: <http://kanselarij.vo.data.gift/id/agendas/>
@@ -30,14 +30,14 @@ INSERT DATA {
   agenda:${newUUID} besluitvorming:heeftVorigeVersie <${oldAgendaURI}>  .
 }
 }`;
-    await mu.query(query).catch(err => {
-        console.error(err)
-    });
-    return [newUUID, "http://kanselarij.vo.data.gift/id/agendas/" + newUUID];
+  await mu.query(query).catch(err => {
+    console.error(err)
+  });
+  return [newUUID, "http://kanselarij.vo.data.gift/id/agendas/" + newUUID];
 };
 
 const getSubcasePhaseCode = async () => {
-    const query = `
+  const query = `
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -54,15 +54,15 @@ const getSubcasePhaseCode = async () => {
     }
   }
 `;
-    const data = await mu.query(query).catch(err => {
-        console.error(err)
-    });
-    console.log(data);
-    return data.results.bindings[0].code.value;
+  const data = await mu.query(query).catch(err => {
+    console.error(err)
+  });
+  console.log(data);
+  return data.results.bindings[0].code.value;
 };
 
 const getSubcasePhasesOfAgenda = async (newAgendaId, codeURI) => {
-    const query = `
+  const query = `
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -84,14 +84,14 @@ const getSubcasePhasesOfAgenda = async (newAgendaId, codeURI) => {
     }
   }
 `;
-    return await mu.query(query).catch(err => {
-        console.error(err)
-    });
+  return await mu.query(query).catch(err => {
+    console.error(err)
+  });
 };
 
 const storeAgendaItemNumbers = async (agendaUri) => {
-    const maxAgendaItemNumberSoFar = await getHighestAgendaItemNumber(agendaUri);
-    let query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+  const maxAgendaItemNumberSoFar = await getHighestAgendaItemNumber(agendaUri);
+  let query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -109,19 +109,19 @@ const storeAgendaItemNumbers = async (agendaUri) => {
       ?agendaItem ext:agendaItemNumber ?number .
     }
   } ORDER BY ?priorityOrMax`;
-    const sortedAgendaItemsToName = await mu.query(query).catch(err => {
-        console.error(err)
-    });
-    const triples = [];
-    sortedAgendaItemsToName.results.bindings.map((binding, index) => {
-        triples.push(`<${binding['agendaItem'].value}> ext:agendaItemNumber ${maxAgendaItemNumberSoFar + index} .`);
-    });
+  const sortedAgendaItemsToName = await mu.query(query).catch(err => {
+    console.error(err)
+  });
+  const triples = [];
+  sortedAgendaItemsToName.results.bindings.map((binding, index) => {
+    triples.push(`<${binding['agendaItem'].value}> ext:agendaItemNumber ${maxAgendaItemNumberSoFar + index} .`);
+  });
 
-    if (triples.length < 1) {
-        return;
-    }
+  if (triples.length < 1) {
+    return;
+  }
 
-    query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+  query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -134,13 +134,13 @@ const storeAgendaItemNumbers = async (agendaUri) => {
       ${triples.join("\n")}
     }
   }`;
-    await mu.query(query).catch(err => {
-        console.log(err);
-    })
+  await mu.query(query).catch(err => {
+    console.log(err);
+  })
 };
 
 const getHighestAgendaItemNumber = async (agendaUri) => {
-    const query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+  const query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -157,13 +157,13 @@ const getHighestAgendaItemNumber = async (agendaUri) => {
       ?otherAgenda dct:hasPart ?agendaItem .
       ?agendaItem ext:agendaItemNumber ?number .
   }`;
-    const response = await mu.query(query);
-    return parseInt(((response.results.bindings[0] || {})['max'] || {}).value || 0);
+  const response = await mu.query(query);
+  return parseInt(((response.results.bindings[0] || {})['max'] || {}).value || 0);
 };
 
 //This method is for assigning VR numbers to documents automatically but is currently not being used and will need updating
 const getUnnamedDocumentsOfAgenda = async (agendaUri) => {
-    const query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+  const query = `PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -208,33 +208,33 @@ const getUnnamedDocumentsOfAgenda = async (agendaUri) => {
   } ORDER BY ?agendaItem ?documentPriority
   `;
 
-    return await mu.query(query).catch(err => {
-        console.error(err)
-    });
+  return await mu.query(query).catch(err => {
+    console.error(err)
+  });
 };
 const createNewSubcasesPhase = async (codeURI, subcaseListOfURIS) => {
-    if (subcaseListOfURIS.length < 1) {
-        return;
-    }
-    const listOfQueries = await subcaseListOfURIS.map((subcaseURI) => {
-        const newUUID = uuidv4();
-        const newURI = `http://data.vlaanderen.be/id/ProcedurestapFase/${newUUID}`;
-        return `
+  if (subcaseListOfURIS.length < 1) {
+    return;
+  }
+  const listOfQueries = await subcaseListOfURIS.map((subcaseURI) => {
+    const newUUID = uuidv4();
+    const newURI = `http://data.vlaanderen.be/id/ProcedurestapFase/${newUUID}`;
+    return `
     <${newURI}> a   ext:ProcedurestapFase ;
     mu:uuid "${newUUID}" ;
     besluitvorming:statusdatum """${new Date().toISOString()}"""^^xsd:dateTime ;
     ext:procedurestapFaseCode <${codeURI}> .
     <${subcaseURI}> ext:subcaseProcedurestapFase <${newURI}> .
     `
-    });
+  });
 
-    if (listOfQueries.length < 1) {
-        return;
-    }
+  if (listOfQueries.length < 1) {
+    return;
+  }
 
-    const insertString = listOfQueries.join(' ');
-    console.log(insertString);
-    const query = `
+  const insertString = listOfQueries.join(' ');
+  console.log(insertString);
+  const query = `
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -249,13 +249,13 @@ const createNewSubcasesPhase = async (codeURI, subcaseListOfURIS) => {
    }
   };
 `;
-    return await mu.update(query).catch(err => {
-        console.error(err)
-    });
+  return await mu.update(query).catch(err => {
+    console.error(err)
+  });
 };
 
 const getAgendaURI = async (newAgendaId) => {
-    const query = `
+  const query = `
    PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -266,10 +266,10 @@ const getAgendaURI = async (newAgendaId) => {
    }
  `;
 
-    const data = await mu.query(query).catch(err => {
-        console.error(err)
-    });
-    return data.results.bindings[0].agenda.value;
+  const data = await mu.query(query).catch(err => {
+    console.error(err)
+  });
+  return data.results.bindings[0].agenda.value;
 };
 
 const deleteAgendaitems = async (deleteAgendaURI) => {
@@ -288,7 +288,7 @@ const deleteAgendaitems = async (deleteAgendaURI) => {
       ?s ?pp ?agendaitem .
     }
   }`;
-    await mu.query(query);
+  await mu.query(query);
 };
 
 const deleteSubcasePhases = async (deleteAgendaURI) => {
@@ -356,19 +356,19 @@ const deleteAgenda = async (deleteAgendaURI) => {
       }
     }
   }`;
-    await mu.query(query);
+  await mu.query(query);
 };
 
 module.exports = {
-    createNewAgenda,
-    getSubcasePhaseCode,
-    getSubcasePhasesOfAgenda,
-    storeAgendaItemNumbers,
-    getUnnamedDocumentsOfAgenda,
-    createNewSubcasesPhase,
-    getAgendaURI,
-    deleteSubcasePhases,
-    deleteAgendaitems,
-    deleteAgenda
+  createNewAgenda,
+  getSubcasePhaseCode,
+  getSubcasePhasesOfAgenda,
+  storeAgendaItemNumbers,
+  getUnnamedDocumentsOfAgenda,
+  createNewSubcasesPhase,
+  getAgendaURI,
+  deleteSubcasePhases,
+  deleteAgendaitems,
+  deleteAgenda
 };
 

--- a/util/index.js
+++ b/util/index.js
@@ -198,9 +198,7 @@ const copyAgendaItems = async (oldAgendaUri, newAgendaUri) => {
       ?newAgendaitemURI a besluit:Agendapunt ;
         mu:uuid ?newAgendaitemUuid ;
         ext:replacesPrevious ?agendaitem .
-      <${newAgendaUri}> dct:hasPart ?newAgendaitemURI ;
-        besluitvorming:heeftVorigeVersie <${oldAgendaUri}> .
-
+      <${newAgendaUri}> dct:hasPart ?newAgendaitemURI .
     }
   } WHERE { { SELECT * WHERE {
     <${oldAgendaUri}> dct:hasPart ?agendaitem .

--- a/util/index.js
+++ b/util/index.js
@@ -1,5 +1,5 @@
 const repository = require('./../repository/index.js');
-const targetGraph = "http://mu.semte.ch/graphs/organizations/kanselarij";
+const targetGraph = "http://mu.semte.ch/application";
 const batchSize = process.env.BATCH_SIZE || 100;
 const moment = require('moment');
 import mu from 'mu';
@@ -98,6 +98,7 @@ const parseSparqlResults = (data) => {
     })
 };
 
+//This method is for assigning VR numbers to documents automatically but is currently not being used and will need updating
 const nameDocumentsBasedOnAgenda = async (agendaUri) => {
     let response = await repository.getUnnamedDocumentsOfAgenda(agendaUri);
     const mededelingType = "5fdf65f3-0732-4a36-b11c-c69b938c6626";
@@ -195,7 +196,7 @@ const copyAgendaItems = async (oldAgendaUri, newAgendaUri) => {
 
   INSERT { 
     GRAPH <${targetGraph}> {
-      ?newAgendaitemURI a besluit:Agendapunt ;
+        ?newAgendaitemURI a besluit:Agendapunt ;
         mu:uuid ?newAgendaitemUuid ;
         ext:replacesPrevious ?agendaitem .
       <${newAgendaUri}> dct:hasPart ?newAgendaitemURI .

--- a/util/index.js
+++ b/util/index.js
@@ -5,12 +5,12 @@ const moment = require('moment');
 import mu from 'mu';
 
 function getBindingValue(binding, property, fallback) {
-    binding = binding || {};
-    const result = (binding[property] || {}).value;
-    if (typeof result === "undefined") {
-        return fallback;
-    }
-    return result;
+  binding = binding || {};
+  const result = (binding[property] || {}).value;
+  if (typeof result === "undefined") {
+    return fallback;
+  }
+  return result;
 }
 
 const updatePropertiesOnAgendaItems = async function (agendaUri) {
@@ -24,7 +24,7 @@ const updatePropertiesOnAgendaItems = async function (agendaUri) {
   `;
   const data = await mu.query(selectTargets);
   const targets = data.results.bindings.map((binding) => {
-      return binding.target.value;
+    return binding.target.value;
   });
   return updatePropertiesOnAgendaItemsBatched(targets);
 }
@@ -40,7 +40,7 @@ const updatePropertiesOnAgendaItemsBatched = async function (targets) {
     console.log(`Agendaitems list exceeds the batchSize of ${batchSize}, splitting into batches`);
     targetsToDo = targets.splice(0, batchSize);
   }
-    const movePropertiesLeft = `
+  const movePropertiesLeft = `
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -59,9 +59,9 @@ const updatePropertiesOnAgendaItemsBatched = async function (targets) {
     ?previousURI ?p ?o .
     FILTER(?p != mu:uuid)
   }`;
-    await mu.update(movePropertiesLeft);
+  await mu.update(movePropertiesLeft);
 
-    const movePropertiesRight = `
+  const movePropertiesRight = `
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -80,67 +80,67 @@ const updatePropertiesOnAgendaItemsBatched = async function (targets) {
     ?o ?p ?previousURI .
     FILTER(?p != dct:hasPart)
   }`;
-    await mu.update(movePropertiesRight);
+  await mu.update(movePropertiesRight);
 
-    return updatePropertiesOnAgendaItemsBatched(targetsToDo);
+  return updatePropertiesOnAgendaItemsBatched(targetsToDo);
 };
 
 const parseSparqlResults = (data) => {
-    const vars = data.head.vars;
-    return data.results.bindings.map(binding => {
-        let obj = {};
-        vars.forEach(varKey => {
-            if (binding[varKey]) {
-                obj[varKey] = binding[varKey].value;
-            }
-        });
-        return obj;
-    })
+  const vars = data.head.vars;
+  return data.results.bindings.map(binding => {
+    let obj = {};
+    vars.forEach(varKey => {
+      if (binding[varKey]) {
+        obj[varKey] = binding[varKey].value;
+      }
+    });
+    return obj;
+  })
 };
 
 //This method is for assigning VR numbers to documents automatically but is currently not being used and will need updating
 const nameDocumentsBasedOnAgenda = async (agendaUri) => {
-    let response = await repository.getUnnamedDocumentsOfAgenda(agendaUri);
-    const mededelingType = "5fdf65f3-0732-4a36-b11c-c69b938c6626";
+  let response = await repository.getUnnamedDocumentsOfAgenda(agendaUri);
+  const mededelingType = "5fdf65f3-0732-4a36-b11c-c69b938c6626";
 
-    let previousAgendaItem = null;
-    let previousStartingIndex = 0;
-    let triples = [];
+  let previousAgendaItem = null;
+  let previousStartingIndex = 0;
+  let triples = [];
 
-    response.results.bindings.map((binding) => {
+  response.results.bindings.map((binding) => {
 
-        const bindingValue = function (property, fallback) {
-            return getBindingValue(binding, property, fallback);
-        };
-        let item = bindingValue('agendaItem');
-        let numbersSoFar = parseInt(bindingValue('existingNumbers')) || 0;
-        let document = bindingValue('document');
-        let number = parseInt(bindingValue('number'));
-        let date = moment(bindingValue('zittingDate'));
-        let asAnnouncement = bindingValue('announcement', '').indexOf("true") >= 0;
-        let type = bindingValue('dossierType', '').indexOf(mededelingType) >= 0 ? "MED" : "DOC";
-        if (asAnnouncement) {
-            type = "MED";
-        }
-
-        if (previousAgendaItem != item) {
-            previousAgendaItem = item;
-            previousStartingIndex = numbersSoFar;
-        }
-        previousStartingIndex = previousStartingIndex + 1;
-        number = paddNumberWithZeros(number, 4);
-        let month = paddNumberWithZeros(date.month(), 2);
-        let day = paddNumberWithZeros(date.date(), 2);
-        const vrNumber = `"VR ${date.year()} ${month}${day} ${type}.${number}/${previousStartingIndex}"`;
-        triples.push(`<${document}> besluitvorming:stuknummerVR ${vrNumber} .`);
-        triples.push(`<${document}> ext:stuknummerVROriginal ${vrNumber} .`);
-    });
-
-    if (triples.length < 1) {
-        return;
+    const bindingValue = function (property, fallback) {
+      return getBindingValue(binding, property, fallback);
+    };
+    let item = bindingValue('agendaItem');
+    let numbersSoFar = parseInt(bindingValue('existingNumbers')) || 0;
+    let document = bindingValue('document');
+    let number = parseInt(bindingValue('number'));
+    let date = moment(bindingValue('zittingDate'));
+    let asAnnouncement = bindingValue('announcement', '').indexOf("true") >= 0;
+    let type = bindingValue('dossierType', '').indexOf(mededelingType) >= 0 ? "MED" : "DOC";
+    if (asAnnouncement) {
+      type = "MED";
     }
 
-    await mu.query(`PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+    if (previousAgendaItem != item) {
+      previousAgendaItem = item;
+      previousStartingIndex = numbersSoFar;
+    }
+    previousStartingIndex = previousStartingIndex + 1;
+    number = paddNumberWithZeros(number, 4);
+    let month = paddNumberWithZeros(date.month(), 2);
+    let day = paddNumberWithZeros(date.date(), 2);
+    const vrNumber = `"VR ${date.year()} ${month}${day} ${type}.${number}/${previousStartingIndex}"`;
+    triples.push(`<${document}> besluitvorming:stuknummerVR ${vrNumber} .`);
+    triples.push(`<${document}> ext:stuknummerVROriginal ${vrNumber} .`);
+  });
+
+  if (triples.length < 1) {
+    return;
+  }
+
+  await mu.query(`PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -153,41 +153,41 @@ const nameDocumentsBasedOnAgenda = async (agendaUri) => {
           ${triples.join("\n")}
    }
   };`).catch(err => {
-        console.error(err);
-    });
+    console.error(err);
+  });
 };
 
 function paddNumberWithZeros(number, length) {
-    let string = "" + number;
-    while (string.length < length) {
-        string = 0 + string;
-    }
-    return string;
+  let string = "" + number;
+  while (string.length < length) {
+    string = 0 + string;
+  }
+  return string;
 }
 
 const checkForPhasesAndAssignMissingPhases = async (subcasePhasesOfAgenda, codeURI) => {
-    if (subcasePhasesOfAgenda) {
-        const parsedObjects = parseSparqlResults(subcasePhasesOfAgenda);
-        const uniqueSubcaseIds = [...new Set(parsedObjects.map((item) => item['subcase']))];
-        let subcaseListOfURIS = [];
-        if (uniqueSubcaseIds.length < 1) {
-            return;
-        }
-        await uniqueSubcaseIds.map((id) => {
-            const foundObject = parsedObjects.find((item) => item.subcase === id);
-            if (foundObject && foundObject.subcase && !foundObject.phases) {
-                subcaseListOfURIS.push(foundObject.subcase);
-            }
-            return id;
-        });
-        return await repository.createNewSubcasesPhase(codeURI, subcaseListOfURIS)
+  if (subcasePhasesOfAgenda) {
+    const parsedObjects = parseSparqlResults(subcasePhasesOfAgenda);
+    const uniqueSubcaseIds = [...new Set(parsedObjects.map((item) => item['subcase']))];
+    let subcaseListOfURIS = [];
+    if (uniqueSubcaseIds.length < 1) {
+      return;
     }
+    await uniqueSubcaseIds.map((id) => {
+      const foundObject = parsedObjects.find((item) => item.subcase === id);
+      if (foundObject && foundObject.subcase && !foundObject.phases) {
+        subcaseListOfURIS.push(foundObject.subcase);
+      }
+      return id;
+    });
+    return await repository.createNewSubcasesPhase(codeURI, subcaseListOfURIS)
+  }
 };
 
 const copyAgendaItems = async (oldAgendaUri, newAgendaUri) => {
-    // The bind of ?uuid is a workaround to get a unique id for each STRUUID call.
-    // SUBQUERY: Is needed to make sure we have the same UUID for the URI, since using ?uuid generated a new one
-    const createNewUris = `
+  // The bind of ?uuid is a workaround to get a unique id for each STRUUID call.
+  // SUBQUERY: Is needed to make sure we have the same UUID for the URI, since using ?uuid generated a new one
+  const createNewUris = `
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -211,12 +211,12 @@ const copyAgendaItems = async (oldAgendaUri, newAgendaUri) => {
     BIND(STRAFTER(STR(?newAgendaitemURI), "http://kanselarij.vo.data.gift/id/agendapunten/") AS ?newAgendaitemUuid) 
   }`;
 
-    const result = await mu.update(createNewUris);
-    return updatePropertiesOnAgendaItems(newAgendaUri);
+  const result = await mu.update(createNewUris);
+  return updatePropertiesOnAgendaItems(newAgendaUri);
 };
 
 module.exports = {
-    checkForPhasesAndAssignMissingPhases,
-    updatePropertiesOnAgendaItems,
-    copyAgendaItems
+  checkForPhasesAndAssignMissingPhases,
+  updatePropertiesOnAgendaItems,
+  copyAgendaItems
 };


### PR DESCRIPTION
Service updated to work with the mu-authorization:0.6.0-beta.4:

- Fixed an issue where we inserted a mu:uuid without also inserting a type (was intended), this worked in beta.3 but not in beta.4.
- Changed the approach to copying agendaitems to the new agenda
- Changed the way we batch the work to be done when copying the agendaitems