### PR TITLE
Feature/KAS-1425 model refactor: activity

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,18 +38,8 @@ app.post('/approveAgenda', async (req, res) => {
   // Copy old agenda data to new agenda.
   const agendaData = await util.copyAgendaItems(oldAgendaURI, newAgendaURI);
   await repository.approveAgenda(oldAgendaURI);
-
   await repository.storeAgendaItemNumbers(oldAgendaURI);
 
-  try {
-    const codeURI = await repository.getSubcasePhaseCode();
-    const subcasePhasesOfAgenda = await repository.getSubcasePhasesOfAgenda(newAgendaId, codeURI);
-
-    await util.checkForPhasesAndAssignMissingPhases(subcasePhasesOfAgenda, codeURI);
-    } catch (e) {
-        console.log(`error on ${newAgendaURI}`);
-        console.log("something went wrong while assigning the code 'Geagendeerd' to the agendaitems", e);
-    }
   res.send({status: ok, statusCode: 200, body: { agendaData: agendaData, newAgenda: { id: newAgendaId, uri: newAgendaURI, data: agendaData } } }); // resultsOfSerialNumbers: resultsAfterUpdates
 });
 
@@ -64,7 +54,7 @@ app.post('/deleteAgenda', async (req, res) => {
   }
   try {
     const agendaToDeleteURI = await repository.getAgendaURI(agendaToDeleteId);
-    await repository.deleteSubcasePhases(agendaToDeleteURI);
+    await repository.deleteAgendaActivities(agendaToDeleteURI);
     await repository.deleteAgendaitems(agendaToDeleteURI);
     await repository.deleteAgenda(agendaToDeleteURI);
     res.send({status: ok, statusCode: 200 });

--- a/util/index.js
+++ b/util/index.js
@@ -98,25 +98,6 @@ const parseSparqlResults = (data) => {
   })
 };
 
-const checkForPhasesAndAssignMissingPhases = async (subcasePhasesOfAgenda, codeURI) => {
-  if (subcasePhasesOfAgenda) {
-    const parsedObjects = parseSparqlResults(subcasePhasesOfAgenda);
-    const uniqueSubcaseIds = [...new Set(parsedObjects.map((item) => item['subcase']))];
-    let subcaseListOfURIS = [];
-    if (uniqueSubcaseIds.length < 1) {
-      return;
-    }
-    await uniqueSubcaseIds.map((id) => {
-      const foundObject = parsedObjects.find((item) => item.subcase === id);
-      if (foundObject && foundObject.subcase && !foundObject.phases) {
-        subcaseListOfURIS.push(foundObject.subcase);
-      }
-      return id;
-    });
-    return await repository.createNewSubcasesPhase(codeURI, subcaseListOfURIS)
-  }
-};
-
 const copyAgendaItems = async (oldAgendaUri, newAgendaUri) => {
   // The bind of ?uuid is a workaround to get a unique id for each STRUUID call.
   // SUBQUERY: Is needed to make sure we have the same UUID for the URI, since using ?uuid generated a new one
@@ -149,7 +130,6 @@ const copyAgendaItems = async (oldAgendaUri, newAgendaUri) => {
 };
 
 module.exports = {
-  checkForPhasesAndAssignMissingPhases,
   updatePropertiesOnAgendaItems,
   copyAgendaItems
 };


### PR DESCRIPTION
# :mag:  KAS-1425: Model refactor: activity model gebruiken
De refactor verlegt de relatie tussen procedurstap en agendaitem naar een tussenobject: de agendering-activiteit
Bij de refactor hoort ook een deel opkuis van: postponed, procedurestapfases en fasecodes.

## ✏️  What has changed

### app.js:
Heel de blok van het aanmaken van een procedurestapfase verwijdert
backstory: een agendaitem dat voor een eerste keer op een ontwerpagenda stond had enkel de fase 'ingediend',
na goedkeuren in deze service moesten we dan een nieuwe fase aanmaken 'geagendeerd'

Deze fases worden nu afgeleid van de agendering-activiteit (in custom-subcase-services):
Bestaat de activiteit ? => 'ingediend'
Heeft de activiteit een agendaitem op een goedgekeurde agenda? => 'geagendeerd'

Bij verwijderen van de agenda moeten we ipv opkuis van fases nu opkuis doen van agendering-activiteiten.
(agendaitems die voor de eerste keer op de ontwerpagenda staan als de agenda verwijdert moeten terug agendeerbaar kunnen worden, en dat betekent het verwijderen van die activiteit)

### repository/index.js:
Verwijderen oude code mbt fases
aanpassen bestaande delete functie om te werken met agendering-activiteiten

### util/index.js:
Verwijderen oude code mbt fases


