### PR TITLE
KAS-1644: Fix forgotten query type

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -36,7 +36,7 @@ INSERT DATA {
     GRAPH <${targetGraph}> { 
         ${sparqlEscapeUri(newAgendaUri)} a besluitvorming:Agenda ;
             mu:uuid ${sparqlEscapeString(newAgendaUuid)} ;
-            dct:created ${sparqlEscapeDate(creationDate)} ;
+            dct:created ${sparqlEscapeDateTime(creationDate)} ;
             dct:modified ${sparqlEscapeDateTime(creationDate)} ;
             dct:title ${sparqlEscapeString(title)} ;
             besluitvorming:agendaStatus ${sparqlEscapeUri(AGENDA_STATUS_DESIGN)} ;


### PR DESCRIPTION
# 😬  KAS-1644: Fix forgotten query type

In deze PR hebben we een query aangepast die vergeten was in story KAS-1644.
Het juiste type zou nu ook bij de creatie moeten gehanteerd worden.

## ✏️ What has been done
- Insert query voor een agenda aangepast van date naar datetime op de `created` property