### PR TITLE
KAS-2376 break up complex query, separate delete methods

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,7 +44,7 @@ app.post('/deleteAgenda', async (req, res) => {
   }
   try {
     const agendaToDeleteURI = await getAgendaURI(agendaToDeleteId);
-    await agendaDeletion.deleteAgendaActivities(agendaToDeleteURI);
+    await agendaDeletion.cleanupNewAgendaitems(agendaToDeleteURI);
     await agendaDeletion.deleteAgendaitems(agendaToDeleteURI);
     await agendaDeletion.deleteAgenda(agendaToDeleteURI);
     res.send({status: ok, statusCode: 200 });

--- a/repository/delete-agenda.js
+++ b/repository/delete-agenda.js
@@ -12,15 +12,15 @@ const targetGraph = 'http://mu.semte.ch/application';
  */
 const deleteAgendaitems = async (deleteAgendaURI) => {
   const agendaItemUrisQueryResult = await selectAgendaItems(deleteAgendaURI);
-  const listOfAgendaitemUris = agendaItemUrisQueryResult.map(uri => uri.agendaitem);
+  const listOfAgendaItemUris = agendaItemUrisQueryResult.map(uri => uri.agendaitem);
 
-  for (const agendaItemUri of listOfAgendaitemUris) {
+  for (const agendaItemUri of listOfAgendaItemUris) {
     await deleteAgendaitem(agendaItemUri);
   }
 };
 
 /**
- * Deletes the relations and its content of an agendaItem.
+ * Deletes the relations and its content of an agendaitem.
  * @description This function will delete all predicates that are related to agendaitem.
  * @name deleteAgendaitem
  * @function

--- a/repository/delete-agenda.js
+++ b/repository/delete-agenda.js
@@ -1,5 +1,6 @@
 import mu, { sparqlEscapeUri } from 'mu';
 import { selectAgendaItems } from './agenda-general';
+import * as util from '../util/index';
 
 const targetGraph = 'http://mu.semte.ch/application';
 
@@ -11,10 +12,10 @@ const targetGraph = 'http://mu.semte.ch/application';
  */
 const deleteAgendaitems = async (deleteAgendaURI) => {
   const agendaItemUrisQueryResult = await selectAgendaItems(deleteAgendaURI);
-  const listOfAgendaItemUris = agendaItemUrisQueryResult.map(uri => uri.agendaitem);
+  const listOfAgendaitemUris = agendaItemUrisQueryResult.map(uri => uri.agendaitem);
 
-  for (const agendaItemUri of listOfAgendaItemUris) {
-    await deleteAgendaitem(deleteAgendaURI, agendaItemUri);
+  for (const agendaItemUri of listOfAgendaitemUris) {
+    await deleteAgendaitem(agendaItemUri);
   }
 };
 
@@ -23,10 +24,9 @@ const deleteAgendaitems = async (deleteAgendaURI) => {
  * @description This function will delete all predicates that are related to agendaitem.
  * @name deleteAgendaitem
  * @function
- * @param {String} deleteAgendaURI - The URI of the agenda
  * @param {String} agendaitemUri - The URI of the agendaitem which is the startpoint
  */
-const deleteAgendaitem = async (deleteAgendaURI, agendaItemUri) => {
+const deleteAgendaitem = async (agendaItemUri) => {
   const query = `
   PREFIX dct: <http://purl.org/dc/terms/>
 
@@ -44,11 +44,77 @@ const deleteAgendaitem = async (deleteAgendaURI, agendaItemUri) => {
   await mu.query(query);
 };
 
-const deleteAgendaActivities = async (deleteAgendaURI) => {
+/**
+ * @description This function will delete all predicates of a newsletter that is linked to the agendaitem. 
+ * @name deleteAgendaitemNewsletterInfo
+ * @function
+ * @param {String} agendaitemUri - The URI of the agendaitem which is the startpoint
+ */
+const deleteAgendaitemNewsletterInfo = async (agendaitemUri) => {
+  const query = `
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+
+  DELETE {
+    GRAPH <${targetGraph}> {
+    ?newsletter ?p ?o .
+    }
+  }
+  
+  WHERE {
+    GRAPH <${targetGraph}> { 
+      ?treatment besluitvorming:heeftOnderwerp ${sparqlEscapeUri(agendaitemUri)} .
+      ?treatment a besluit:BehandelingVanAgendapunt .
+      OPTIONAL {
+        ?treatment prov:generated ?newsletter .
+        ?newsletter a besluitvorming:NieuwsbriefInfo .
+        ?newsletter ?p ?o .
+      }
+    }
+  }`;
+  await mu.query(query);
+};
+
+/**
+ * @description This function will delete all predicates of treatments that are linked to the agendaitem. 
+ * @name deleteAgendaitemTreatments
+ * @function
+ * @param {String} agendaitemUri - The URI of the agendaitem which is the startpoint
+ */
+const deleteAgendaitemTreatments = async (agendaitemUri) => {
+  const query = `
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+
+  DELETE {
+    GRAPH <${targetGraph}> {
+    ?treatment ?p ?o .
+    }
+  }
+  
+  WHERE {
+    GRAPH <${targetGraph}> { 
+      ?treatment besluitvorming:heeftOnderwerp ${sparqlEscapeUri(agendaitemUri)} .
+      ?treatment a besluit:BehandelingVanAgendapunt .
+      ?treatment ?p ?o .
+    }
+  }`;
+  await mu.query(query);
+};
+
+/**
+ * @description This function will delete the agenda-activity that is linked to the agendaitem.
+ * Also deletes the relation between the meeting and the subcase.
+ * @name deleteAgendaActivity
+ * @function
+ * @param {String} agendaitemUri - The URI of the agendaitem which is the startpoint
+ */
+const deleteAgendaActivity = async (agendaitemUri) => {
   const query = `
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
-  PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 
   DELETE {
@@ -56,24 +122,52 @@ const deleteAgendaActivities = async (deleteAgendaURI) => {
     ?subcase ext:isAangevraagdVoor ?session .
     ?activity a besluitvorming:Agendering .
     ?activity besluitvorming:vindtPlaatsTijdens ?subcase .
-    ?activity besluitvorming:genereertAgendapunt ?agendapunt . 
+    ?activity besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitemUri)} . 
     ?activity ?p ?o .
     }
   }
-  
- WHERE {
+  WHERE {
     GRAPH <${targetGraph}> {
-
-    ?subcase a dossier:Procedurestap .
-    OPTIONAL { ?subcase ext:isAangevraagdVoor ?session .}
-    OPTIONAL { 
-      ?activity besluitvorming:genereertAgendapunt ?agendapunt .
+      ?subcase a dossier:Procedurestap .
+      OPTIONAL { ?subcase ext:isAangevraagdVoor ?session  .}
       ?activity a besluitvorming:Agendering .
-      ?activity ?p ?o . 
+      ?activity besluitvorming:vindtPlaatsTijdens ?subcase .
+      ?activity besluitvorming:genereertAgendapunt ${sparqlEscapeUri(agendaitemUri)} .
+      ?activity ?p ?o .
     }
-    
-      FILTER (?totalitems = 1)  {
+  }`;
+  await mu.query(query);
+};
 
+/** 
+ * @description This function will check for each agendaitem on the agenda how many agendaitems are connected to the agenda-activity
+ * - If there is exactly 1 agendaitem = clean up the data so subcase is proposable again:
+ * newsletters linked to linked treatments
+ * linked treatments
+ * deleting the agenda-activity / link between meeting and subcase
+ * - If there is 0 or more than 1 = do nothing with those agendaitems (0 can be approval, 2 means there is an agendaitem on an approved agenda)
+ * @name cleanupNewAgendaitems
+ * @function
+ * @param {String} deleteAgendaURI - The URI of the agenda
+ */
+const cleanupNewAgendaitems = async (deleteAgendaURI) => {
+  const selectQuery = `
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+
+  SELECT DISTINCT ?agendapunt WHERE {
+    GRAPH <${targetGraph}> {
+      ?subcase a dossier:Procedurestap .
+      OPTIONAL { ?subcase ext:isAangevraagdVoor ?session .}
+      OPTIONAL { 
+        ?activity besluitvorming:genereertAgendapunt ?agendapunt .
+        ?activity a besluitvorming:Agendering .
+      }
+      FILTER (?totalitems = 1)
+      {
         SELECT (count(*) AS ?totalitems) ?subcase ?activity WHERE {
           GRAPH <${targetGraph}> {
             ${sparqlEscapeUri(deleteAgendaURI)} dct:hasPart ?agendaitems .
@@ -84,15 +178,22 @@ const deleteAgendaActivities = async (deleteAgendaURI) => {
             ?activity besluitvorming:genereertAgendapunt ?agendaitems . 
             ?activity besluitvorming:genereertAgendapunt ?totalitems . 
           }
-        }
-        GROUP BY ?subcase ?activity
+        } GROUP BY ?subcase ?activity
       }
-       
     }
   }
   `;
-  await mu.query(query);
-};
+  const result = await mu.query(selectQuery);
+  const targetAgendaitems = util.parseSparqlResults(result);
+  console.log(`##### Found ${targetAgendaitems.length} agendaitem(s) that need extra cleanup #####`);
+  const listOfAgendaitemUris = targetAgendaitems.map(uri => uri.agendapunt);
+
+  for (const agendaitemUri of listOfAgendaitemUris) {
+    await deleteAgendaitemNewsletterInfo(agendaitemUri);
+    await deleteAgendaitemTreatments(agendaitemUri);
+    await deleteAgendaActivity(agendaitemUri);
+  }
+}
 
 const deleteAgenda = async (deleteAgendaURI) => {
   const query = `
@@ -117,6 +218,6 @@ const deleteAgenda = async (deleteAgendaURI) => {
 
 export {
   deleteAgendaitems,
-  deleteAgendaActivities,
+  cleanupNewAgendaitems,
   deleteAgenda
 };


### PR DESCRIPTION
# What has changed

De bestaande methode "**deleteAgendaActivities**" deed hetvolgende:

Bij een delete van een agenda moeten we weten welke agendapunten nieuw waren.
Bij die punten moeten we namelijk opkuis doen van de agenda-activity en de link tussen subcase en meeting om deze terug agendeerbaar te maken.
De manier waarop is door in een subquery te checken hoeveel agendaitems zich bevinden in de agenda-activity.
Als er maar 1 agendaitem in de activity zit dan moet die worden opgekuist

Echter bij de komst van treatments hebben we na deze functie nog wat onopgekuiste data.
Zowel de treatment zelf als mogelijke nieuwsbrieven dat gelinkt zijn daaraan moeten worden opgekuist.

Omdat alles in 1 query doen te veel results oplevert gekozen om dat uit elkaar te halen in nieuwe functie "**cleanupNewAgendaitems**"

Select van alle agendaitems die een agenda-activity hebben waar er exact 1 agendaitem in zit in totaal
(die query met filter en subquery is grotendeels hetzelfde gebleven,)
Die selected agendaitems zijn de targets waarvan we dan 1 voor 1 opkuis moeten van doen:
- opkuis nieuwsbrief info (indien aanwezig) via gelinkte treatments  (er zou maar 1 max mogen zijn volgens data model, meerdere treatments zouden moeten linken naar dezelfde nieuwsbriefInfo, maar is mogelijk niet het geval)
- opkuis treatments (indien aanwezig, kan 0 of meerdere zijn)
- opkuis agenda-activities en link tussen subcase en meeting