### PR TITLE
KAS-3549: Remove newsletter from meeting

### DIFF
--- a/repository/delete-meeting.js
+++ b/repository/delete-meeting.js
@@ -10,7 +10,6 @@ import * as util from '../util/index';
 */
 const deleteMeetingAndNewsletter = async (meetingURI) => {
   await deletePublicationActivities(meetingURI);
-  await deleteNewsletter(meetingURI);
   await util.sleep();
   await deleteMeeting(meetingURI);
 };
@@ -33,25 +32,6 @@ const deletePublicationActivities = async (meetingURI) => {
   }`;
   await mu.update(query);
 }
-
-const deleteNewsletter = async (meetingURI) => {
-  const query = `
-  PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
-  PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
-
-  DELETE {
-    ?newsletter ?p ?o .
-    ?s ?pp ?newsletter .
-  } WHERE {
-    ${sparqlEscapeUri(meetingURI)} ext:algemeneNieuwsbrief ?newsletter .
-    ?newsletter a besluitvorming:NieuwsbriefInfo .
-    OPTIONAL { ?newsletter ?p ?o . }
-    OPTIONAL {
-      ?s ?pp ?newsletter .
-    }
-  }`;
-  await mu.update(query);
-};
 
 const deleteMeeting = async (meetingURI) => {
   const query = `


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1437

Meetings no longer have a relation to newsletters, so we no longer need to remove them when deleting a meeting.