### PR TITLE
Wait on busy with timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ agenda-approval:
   environment:
     CACHE_CLEAR_TIMEOUT: 2000 # adds a timeout before sending a response, to give the cache time to clear.
     SERVER_BUSY_TIMEOUT: 5000 # keeps the server "busy" for the duration of the timeout after the API call response was sent. 
+    WAIT_ON_BUSY_TIMEOUT: 20000 # allows the service to be busy for 20s before indicating it is busy
 ```
 
 ## Reference

--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ const serverBusyTimeout =
 app.post('/agendas/:id/approve', async (req, res, next) => {
   const agendaId = req.params.id;
   try {
-    checkServiceBusy();
+    await checkServiceBusy();
   } catch (e) {
     return next(e);
   }
@@ -105,7 +105,7 @@ app.post('/agendas/:id/approve', async (req, res, next) => {
 app.post('/agendas/:id/close', async (req, res, next) => {
   const agendaId = req.params.id;
   try {
-    checkServiceBusy();
+    await checkServiceBusy();
   } catch (e) {
     return next(e);
   }
@@ -166,7 +166,7 @@ app.post('/agendas/:id/close', async (req, res, next) => {
 app.post('/meetings/:id/close', async (req, res, next) => {
   const meetingId = req.params.id;
   try {
-    checkServiceBusy();
+    await checkServiceBusy();
   } catch (e) {
     return next(e);
   }
@@ -221,7 +221,7 @@ app.post('/meetings/:id/close', async (req, res, next) => {
  app.post('/agendas/:id/reopen', async (req, res, next) => {
   const agendaId = req.params.id;
   try {
-    checkServiceBusy();
+    await checkServiceBusy();
   } catch (e) {
     return next(e);
   }
@@ -281,7 +281,7 @@ app.post('/meetings/:id/close', async (req, res, next) => {
 app.delete('/agendas/:id', async (req, res, next) => {
   const agendaId = req.params.id;
   try {
-    checkServiceBusy();
+    await checkServiceBusy();
   } catch (e) {
     return next(e);
   }
@@ -352,7 +352,7 @@ app.delete('/agendas/:id', async (req, res, next) => {
 app.post('/meetings/:id/reopen', async (req, res, next) => {
   const meetingId = req.params.id;
   try {
-    checkServiceBusy();
+    await checkServiceBusy();
   } catch (e) {
     return next(e);
   }

--- a/util/index.js
+++ b/util/index.js
@@ -1,4 +1,5 @@
 const sleepTimeout = process.env.SLEEP_TIMEOUT || 5000;
+const waitOnBusyTimeoutMs = process.env.WAIT_ON_BUSY_TIMEOUT || 20000;
 
 const parseSparqlResults = (data) => {
   const vars = data.head.vars;
@@ -10,7 +11,7 @@ const parseSparqlResults = (data) => {
       }
     });
     return obj;
-  })
+  });
 };
 
 function sleep() {
@@ -19,13 +20,31 @@ function sleep() {
   });
 }
 
-/* Util to reserve the service to avoid concurrency */
+/**
+ * Util to reserve the service to avoid concurrency
+ *
+ * Checks if the service is busy, then routinely checks for
+ * WAIT_ON_BUSY_TIMEOUT milliseconds to see if the service has become
+ * available.
+ *
+ * NOTE: Can be improved by making serviceBusy a promise but care must
+ * be taken this happens in a single thread with checkServiceBusy.
+ */
 let serviceBusy = false;
-function checkServiceBusy() {
+async function checkServiceBusy() {
+  let maxDate = null; // we set this later so the case of too little time to wait is handled
+  while( serviceBusy && ( !maxDate || maxDate >= new Date() ) ) {
+    maxDate ||= new Date( Date.now() + waitOnBusyTimeoutMs );
+    // wait 50ms to join next runloop for trying again
+    await new Promise( (res) => setTimeout( res, 100 ) );
+  }
+
   if (serviceBusy) {
     let error = new Error('Agenda service is busy. Please refresh and try again later');
     error.status = 500;
     throw error;
+  } else {
+    return false;
   }
 }
 function setServiceBusy(value) {


### PR DESCRIPTION
When the service is busy, the system will wait up to (configurable) 20
seconds before giving up.  This enhances the previous state where the
service threw an error immediately.